### PR TITLE
Add default value for suppressions file location

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -40,13 +40,14 @@ You can see the original Google java style guide (the base of this customization
     <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
     <!-- Customization: If anyone wants to add suppression file, it must be located beside the main file.-->
     <module name="SuppressionFilter">
-        <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
+        <property name="file" value="${config_loc}/checkstyle-suppressions.xml"
+                  default="checkstyle-suppressions.xml"/>
         <property name="optional" value="true"/>
     </module>
     <!-- Customization: We ignore 'MissingJavadocType' errors on test files.-->
     <module name="SuppressionSingleFilter">
         <property name="checks" value="MissingJavadocType"/>
-        <property name="files" value="^.*/src/test/java/.*Test\.java$"/>
+        <property name="files" value="^.*Test\.java$"/>
     </module>
 
     <!-- Checks for whitespace                               -->

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-Version: 2
+Version: 3
 
 This is Sahab's customization of Google java style guide. This file is maintained at the following address:
  https://github.com/sahabpardaz/java-styleguide/blob/master/checkstyle.xml
@@ -47,7 +47,7 @@ You can see the original Google java style guide (the base of this customization
     <!-- Customization: We ignore 'MissingJavadocType' errors on test files.-->
     <module name="SuppressionSingleFilter">
         <property name="checks" value="MissingJavadocType"/>
-        <property name="files" value="^.*Test\.java$"/>
+        <property name="files" value="^.*/src/test/java/.*Test\.java$"/>
     </module>
 
     <!-- Checks for whitespace                               -->


### PR DESCRIPTION
Maven checkstyle plugin hasn't config_loc property, so we use default value for suppression file when we don't need to suppress in the project.